### PR TITLE
Update to the roodi.yml file to parse under Psych

### DIFF
--- a/roodi.yml
+++ b/roodi.yml
@@ -1,16 +1,25 @@
 AssignmentInConditionalCheck:    { }
 CaseMissingElseCheck:            { }
-ClassLineCountCheck:             { line_count: 300 }
-ClassNameCheck:                  { pattern: !ruby/regexp /^[A-Z][a-zA-Z0-9]*$/ }
-ClassVariableCheck:              { }
-CyclomaticComplexityBlockCheck:  { complexity: 4 }
-CyclomaticComplexityMethodCheck: { complexity: 8 }
+ClassLineCountCheck:             
+  line_count: 300 
+ClassNameCheck:                  
+  pattern: !ruby/regexp /^[A-Z][a-zA-Z0-9]*$/
+ClassVariableCheck:              {}
+CyclomaticComplexityBlockCheck:  
+  complexity: 4
+CyclomaticComplexityMethodCheck: 
+  complexity: 8
 EmptyRescueBodyCheck:            { }
 ForLoopCheck:                    { }
-MethodLineCountCheck:            { line_count: 20 }
-MethodNameCheck:                 { pattern: !ruby/regexp /^[_a-z<>=\[|+-\/\*`]+[_a-z0-9_<>=~@\[\]]*[=!\?]?$/ }
+MethodLineCountCheck:            
+  line_count: 20 
+MethodNameCheck:                 
+  pattern: !ruby/regexp /^[_a-z<>=\[|+-\/\*`]+[_a-z0-9_<>=~@\[\]]*[=!\?]?$/ 
 # MissingForeignKeyIndexCheck:     { }
-ModuleLineCountCheck:            { line_count: 300 }
-ModuleNameCheck:                 { pattern: !ruby/regexp /^[A-Z][a-zA-Z0-9]*$/ }
-ParameterNumberCheck:            { parameter_count: 5 }
+ModuleLineCountCheck:            
+  line_count: 300
+ModuleNameCheck:          
+  pattern: !ruby/regexp /^[A-Z][a-zA-Z0-9]*$/
+ParameterNumberCheck:            
+  parameter_count: 5
  


### PR DESCRIPTION
In Ruby 1.9, the psych yaml parser barfs on the roodi.yml file.

I've just reformatted to parse correctly under both Psych and Syck.
