### PR TITLE
The rubygems source now uses https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec
 


### PR DESCRIPTION
The old source was insecure and resulted in the following message:
"The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible,
or 'http://rubygems.org' if not."
