### PR TITLE
Loosen ruby_parser version dependency

### DIFF
--- a/roodi.gemspec
+++ b/roodi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*.rb'] + Dir['bin/*'] + Dir['[A-Za-z]*'] + Dir['spec/**/*']
   gem.version = Roodi::VERSION.dup
   gem.platform = Gem::Platform::RUBY
-  gem.add_runtime_dependency("ruby_parser", "~> 3.2.2")
+  gem.add_runtime_dependency("ruby_parser", [">= 3.2.2", "~> 3.2"])
   gem.executables = ["roodi", "roodi-describe"]
   gem.files = `git ls-files`.split($\)
   gem.test_files =  gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
This PR specifies all 3.x versions of ruby_parser greater that 3.2.2

All the metric_fu dependencies the require ruby_parser are on 3.x, but because roodi specifies ~> 3.2.2, it prohibits install of any libraries (such as reek), that require 3.1

Also see https://github.com/troessner/reek/pull/187
