### PR TITLE
send args to roodi_task will make it easier to add custom configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Add the following to your Rakefile:
     RoodiTask.new
     task :default => [:roodi]
 
+or if you want to supply your own config file...
+
+    require 'roodi_task'
+    RoodiTask.new :config => 'config/roodi.yml'
+    task :default => [:roodi]
+
 ## Custom Configuration
 
 To change the set of checks included, or to change the default values of the checks, you can provide your own config file.  The config file is a YAML file that lists the checks to be included.  Each check can optionally include a hash of options that are passed to the check to configure it.  For example, the default config file looks like this:

--- a/lib/roodi_task.rb
+++ b/lib/roodi_task.rb
@@ -7,10 +7,10 @@ class RoodiTask < Rake::TaskLib
   attr_accessor :config
   attr_accessor :verbose
 
-  def initialize name = :roodi, patterns = nil, config = nil
-    @name      = name
-    @patterns  = patterns || []
-    @config    = config
+  def initialize args = {}
+    @name      = args[:name] || :roodi
+    @patterns  = args[:patterns] || []
+    @config    = args[:config]
     @verbose   = Rake.application.options.trace
 
     yield self if block_given?


### PR DESCRIPTION
This change will make it easier to use a custom configuration from a rake task.

Before you would have specify the name and pattern just to be able to include the configuration
  RoodiTask.new :roodi, nil, "config/roodi.yml"

After you will just pass it the the config variable
 RoodiTask.new :config => "config/roodi.yml"

This change will not effect users who are not passing in any parameters.
