### PR TITLE
fix deprecated syntax for case/when blocks

### DIFF
--- a/spec/roodi/checks/case_missing_else_check_spec.rb
+++ b/spec/roodi/checks/case_missing_else_check_spec.rb
@@ -8,7 +8,7 @@ describe Roodi::Checks::CaseMissingElseCheck do
   it "should accept case statements that do have an else" do
     content = <<-END
     case foo
-      when "bar": "ok"
+      when "bar" then "ok"
       else "good"
     end
     END
@@ -20,8 +20,8 @@ describe Roodi::Checks::CaseMissingElseCheck do
   it "should reject case statements that do have an else" do
     content = <<-END
     case foo
-      when "bar": "ok"
-      when "bar": "bad"
+      when "bar" then "ok"
+      when "bar" then "bad"
     end
     END
     @roodi.check_content(content)


### PR DESCRIPTION
these tests are failing with newer version of ruby-parser (3.15.x), but pass when replacing the deprecated 'colon' syntax by 'then' (or new lines).